### PR TITLE
Fixes #40. Warns if `{` not on its own line

### DIFF
--- a/src/roslint/cpplint_wrapper.py
+++ b/src/roslint/cpplint_wrapper.py
@@ -96,7 +96,7 @@ def CheckBraces(fn, filename, clean_lines, linenum, error):
         m = Match(r'^(.*){(.*)$', line)
         if m and not (IsBlankLine(m.group(1))):
             # Line contains a starting brace and is not empty, uh oh.
-            if "=" in line:
+            if "=" in line and Match(r'\)( *){$', line):
                 # Opening brace is permissable in case of an initializer.
                 pass
             else:


### PR DESCRIPTION
Fixes issue #40 where there were no warnings for the following common
statements:

```C++
if (i == 0) {
for (int i = 0; i < 10; i++) {
while (i == 0) {
```