### PR TITLE
Set the python max-line-length to 120

### DIFF
--- a/scripts/pep8
+++ b/scripts/pep8
@@ -1,11 +1,15 @@
 #!/usr/bin/env python
 
+import sys
 try:
     from roslint import pep8
 except ImportError:
     # Allows the target to work with an un-sourced workspace.
-    import sys, os.path
+    import os.path
     sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "src"))
     from roslint import pep8
 
+# Prepend max line-length so that user can overide it. The number is 1
+# since 0 is the name of the program.
+sys.argv.insert(1, "--max-line-length=120")
 pep8._main()


### PR DESCRIPTION
Allows `rosrun roslint pep8` to run with the expected settings.

Addresses https://github.com/ros/roslint/issues/42, value can still be overridden with `--max-line-length=NUM`