### PR TITLE
Moved cpplint flags to one place

### DIFF
--- a/cmake/roslint-extras.cmake.em
+++ b/cmake/roslint-extras.cmake.em
@@ -26,7 +26,7 @@ macro(_roslint_create_targets)
 endmacro()
 
 # Run a custom lint command on a list of file names.
-# 
+#
 # :param linter: linter command name.
 # :param lintopts: linter options.
 # :param argn: a non-empty list of files to process.
@@ -51,9 +51,6 @@ function(roslint_cpp)
   endif()
   if (NOT DEFINED ROSLINT_CPP_CMD)
     set(ROSLINT_CPP_CMD ${ROSLINT_SCRIPTS_DIR}/cpplint)
-  endif()
-  if (NOT DEFINED ROSLINT_CPP_OPTS)
-    set(ROSLINT_CPP_OPTS "--filter=-runtime/references")
   endif()
   roslint_custom("${ROSLINT_CPP_CMD}" "${ROSLINT_CPP_OPTS}" ${ARGN})
 endfunction()

--- a/scripts/cpplint
+++ b/scripts/cpplint
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import sys
 try:
     from roslint import cpplint_wrapper
 except ImportError:
@@ -8,4 +9,8 @@ except ImportError:
     sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "src"))
     from roslint import cpplint_wrapper
 
+# Adding default flags to cpplint.
+# You can override them using global CMAKE variable ROSLINT_CPP_OPTS.
+# The index of injected argument is 1 because 0 is program's name
+sys.argv.insert(1, "--filter=-runtime/references")
 cpplint_wrapper.main()


### PR DESCRIPTION
Moved default flags for cpplint from cmake file to cpplint script to have centralized place for such flag. This is applicable for running roslint using roslint_add_test() in the CMakeLists.txt file or using command 
**rosrun roslint cpplint <path to file>** 
which allow to make quick local check of the code style.
Related to issue https://github.com/ros/roslint/issues/42