### PR TITLE
Install patched cpplint to global bin dir

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,5 +5,6 @@ setup(**generate_distutils_setup(
     packages=['roslint'],
     package_dir={
       '': 'src'
-      }
+      },
+    scripts=['scripts/cpplint'],
 ))


### PR DESCRIPTION
This is needed to use patched cpplint in editors syntastic checkers
like https://github.com/scrooloose/syntastic for vim.