### PR TITLE
Define xrange() for Python 3

### DIFF
--- a/src/roslint/cpplint.py
+++ b/src/roslint/cpplint.py
@@ -52,6 +52,11 @@ import string
 import sys
 import unicodedata
 
+try:
+  xrange          # Python 2
+except NameError:
+  xrange = range  # Python 3
+
 
 _USAGE = """
 Syntax: cpplint.py [--verbose=#] [--output=vs7] [--filter=-x,+y,...]


### PR DESCRIPTION
__xrange()__ is called 21 times in this file but it was removed from Python 3 in favor of __range()__.