### PR TITLE
Fixing bracer-init-lists (C++11) passed as arguments

### DIFF
--- a/src/roslint/cpplint_wrapper.py
+++ b/src/roslint/cpplint_wrapper.py
@@ -86,7 +86,7 @@ def CheckBraces(fn, filename, clean_lines, linenum, error):
     """ Complete replacement for cpplint.CheckBraces, since the brace rules for ROS C++ Style
         are completely different from the Google style guide ones. """
     line = clean_lines.elided[linenum]
-    if Match(r'^(.*){(.*)}.?$', line):
+    if Match(r'^(.*){(.*)}.*$', line):
         # Special case when both braces are on the same line together, as is the
         # case for one-line getters and setters, for example, or rows of a multi-
         # dimenstional array initializer.


### PR DESCRIPTION
Fixing bug from #62, where bracer-init-lists contained in a single-line would not be accepted due to the fact that the matcher only allowed one character after the right bracer (`}`)