### PR TITLE
Unapproved C++11 header issue

### DIFF
--- a/src/roslint/cpplint.py
+++ b/src/roslint/cpplint.py
@@ -5967,12 +5967,7 @@ def FlagCxx11Features(filename, clean_lines, linenum, error):
   # Flag unapproved C++11 headers.
   include = Match(r'\s*#\s*include\s+[<"]([^<"]+)[">]', line)
   if include and include.group(1) in ('cfenv',
-                                      'condition_variable',
                                       'fenv.h',
-                                      'future',
-                                      'mutex',
-                                      'thread',
-                                      'chrono',
                                       'ratio',
                                       'regex',
                                       'system_error',


### PR DESCRIPTION
I remove headers <condition_variable>, <future>, <mutex>, <thread>, <chrono> from the unapproved C++11 header list, because they compile fine with C++11 and could be useful for ROS projects. Might further consider removing this whole test.