### PR TITLE
Declare noqa on 'uncode' which was remove in Python 3

### DIFF
--- a/src/roslint/cpplint.py
+++ b/src/roslint/cpplint.py
@@ -4363,7 +4363,7 @@ def GetLineWidth(line):
     The width of the line in column positions, accounting for Unicode
     combining characters and wide characters.
   """
-  if isinstance(line, unicode):
+  if isinstance(line, unicode):  # noqa
     width = 0
     for uc in unicodedata.normalize('NFC', line):
       if unicodedata.east_asian_width(uc) in ('W', 'F'):


### PR DESCRIPTION
__unicode__ was removed in Python 3 because all __str__ are Unicode.