### PR TITLE
Support for headers outside of include folder

### DIFF
--- a/src/roslint/cpplint_wrapper.py
+++ b/src/roslint/cpplint_wrapper.py
@@ -76,7 +76,7 @@ def GetHeaderGuardCPPVariable(fn, filename):
     while head:
         head, tail = os.path.split(head)
         var_parts.insert(0, tail)
-        if head.endswith('include') or tail == "":
+        if head.endswith('include') or os.path.exists(os.path.join(head, "package.xml")) or tail == "":
             break
     return re.sub(r'[-./\s]', '_', "_".join(var_parts)).upper()
 


### PR DESCRIPTION
For headers outside of the include folder (like src/my_private_header.h) the current implementation of GetHeaderGuardCPPVariable returns the complete path of the file.

To support those files a new condition was added. The header guards will be relative to the folder with package.xml.