### PR TITLE
add more lint command

### DIFF
--- a/cmake/roslint-extras.cmake.em
+++ b/cmake/roslint-extras.cmake.em
@@ -82,6 +82,18 @@ function(roslint_yaml)
   roslint_custom("${ROSLINT_YAML_CMD}" "-d ${ROSLINT_YAML_OPTS}" "--strict" ${ARGN})
 endfunction()
 
+# Run xmllint on a list of file names.
+#
+function(roslint_xml)
+  if ("${ARGN}" STREQUAL "")
+    file(GLOB_RECURSE ARGN *.xml *.launch)
+  endif()
+  if (NOT DEFINED ROSLINT_XML_CMD)
+    set(ROSLINT_XML_CMD ${ROSLINT_SCRIPTS_DIR}/xmllint)
+  endif()
+  roslint_custom("${ROSLINT_XML_CMD}" "${ROSLINT_XML_OPTS}" ${ARGN})
+endfunction()
+
 # Run markdown lint
 #
 function(roslint_markdown)

--- a/cmake/roslint-extras.cmake.em
+++ b/cmake/roslint-extras.cmake.em
@@ -82,6 +82,18 @@ function(roslint_yaml)
   roslint_custom("${ROSLINT_YAML_CMD}" "-d ${ROSLINT_YAML_OPTS}" "--strict" ${ARGN})
 endfunction()
 
+# Run markdown lint
+#
+function(roslint_markdown)
+  if ("${ARGN}" STREQUAL "")
+    file(GLOB_RECURSE ARGN *.md)
+  endif()
+  if (NOT DEFINED ROSLINT_MARKDOWN_CMD)
+    set(ROSLINT_MARKDOWN_CMD ${ROSLINT_SCRIPTS_DIR}/markdownlint)
+  endif()
+  roslint_custom("${ROSLINT_MARKDOWN_CMD}" "${ROSLINT_MARKDOWN_OPTS}" ${ARGN})
+endfunction()
+
 # Run catkin_lint
 #
 function(roslint_catkin)

--- a/cmake/roslint-extras.cmake.em
+++ b/cmake/roslint-extras.cmake.em
@@ -67,6 +67,21 @@ function(roslint_python)
   roslint_custom("${ROSLINT_PYTHON_CMD}" "${ROSLINT_PYTHON_OPTS}" ${ARGN})
 endfunction()
 
+# Run yamllint on a list of file names.
+#
+function(roslint_yaml)
+  if ("${ARGN}" STREQUAL "")
+    file(GLOB_RECURSE ARGN *.yaml)
+  endif()
+  if (NOT DEFINED ROSLINT_YAML_CMD)
+    set(ROSLINT_YAML_CMD /usr/bin/yamllint)
+  endif()
+  if ("${ROSLINT_YAML_OPTS}" STREQUAL "")
+    set(ROSLINT_YAML_OPTS "{extends: default, rules: {document-start: disable}}")
+  endif()
+  roslint_custom("${ROSLINT_YAML_CMD}" "-d ${ROSLINT_YAML_OPTS}" "--strict" ${ARGN})
+endfunction()
+
 # Run roslint for this package as a test.
 function(roslint_add_test)
   catkin_run_tests_target("roslint" "package" "roslint-${PROJECT_NAME}.xml"

--- a/cmake/roslint-extras.cmake.em
+++ b/cmake/roslint-extras.cmake.em
@@ -82,6 +82,15 @@ function(roslint_yaml)
   roslint_custom("${ROSLINT_YAML_CMD}" "-d ${ROSLINT_YAML_OPTS}" "--strict" ${ARGN})
 endfunction()
 
+# Run catkin_lint
+#
+function(roslint_catkin)
+  if (NOT DEFINED ROSLINT_CATKIN_CMD)
+    set(ROSLINT_CATKIN_CMD ${ROSLINT_SCRIPTS_DIR}/catkin_lint)
+  endif()
+  roslint_custom("${ROSLINT_CATKIN_CMD}" "${ROSLINT_CATKIN_OPTS}" ${PROJECT_SOURCE_DIR})
+endfunction()
+
 # Run roslint for this package as a test.
 function(roslint_add_test)
   catkin_run_tests_target("roslint" "package" "roslint-${PROJECT_NAME}.xml"

--- a/package.xml
+++ b/package.xml
@@ -26,6 +26,7 @@
   <run_depend>python-pylint</run_depend>
   <run_depend>python-cpplint</run_depend>
   -->
+  <run_depend>python-catkin-lint</run_depend>
   <run_depend>yamllint</run_depend>
 
 </package>

--- a/package.xml
+++ b/package.xml
@@ -26,5 +26,6 @@
   <run_depend>python-pylint</run_depend>
   <run_depend>python-cpplint</run_depend>
   -->
+  <run_depend>yamllint</run_depend>
 
 </package>

--- a/package.xml
+++ b/package.xml
@@ -27,6 +27,7 @@
   <run_depend>python-cpplint</run_depend>
   -->
   <run_depend>python-catkin-lint</run_depend>
+  <run_depend>python-lxml</run_depend>
   <run_depend>yamllint</run_depend>
 
 </package>

--- a/scripts/catkin_lint
+++ b/scripts/catkin_lint
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+
+import sys
+from catkin_lint.main import main
+
+# Treat warnings as errors and output result as text with explanations.
+# The number is 1 since 0 is the name of the program.
+sys.argv[1:1] = ["-W2", "--strict", "--explain"]
+print(sys.argv)
+main()

--- a/scripts/markdownlint
+++ b/scripts/markdownlint
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+
+import argparse
+import sys
+try:
+    from roslint import pymarkdownlint_lint as lint
+    from roslint import pymarkdownlint_rules as rules
+    from collections import OrderedDict
+except ImportError:
+    # Allows the target to work with an un-sourced workspace.
+    import os.path
+    sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "src"))
+    from roslint import pymarkdownlint_lint as lint
+    from roslint import pymarkdownlint_rules as rules
+    from collections import OrderedDict
+
+'''
+The MIT License (MIT)
+
+Copyright (c) 2015 Joris Roovers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+'''
+
+
+# LintConfig copied from https://raw.githubusercontent.com/jorisroovers/pymarkdownlint/master/pymarkdownlint/config.py
+class LintConfig(object):
+    """ Class representing markdownlint configuration """
+    default_rule_classes = [rules.MaxLineLengthRule, rules.TrailingWhiteSpace, rules.HardTab]
+
+    def __init__(self):
+        # Use an ordered dict so that the order in which rules are applied is always the same
+        self._rules = OrderedDict([(rule_cls.id, rule_cls()) for rule_cls in self.default_rule_classes])
+
+    @property
+    def rules(self):
+        return self._rules.values()
+
+    def get_rule_by_name_or_id(self, rule_id_or_name):
+        # try finding rule by id
+        rule = self._rules.get(rule_id_or_name)
+        # if not found, try finding rule by name
+        if not rule:
+            rule = next((rule for rule in self.rules if rule.name == rule_id_or_name), None)
+        return rule
+
+# Prepend max line-length so that user can overide it. The number is 1
+# since 0 is the name of the program.
+sys.argv.insert(1, "--max-line-length=120")
+
+parser = argparse.ArgumentParser(description='markdownlint')
+parser.add_argument('--max-line-length', type=int, help='set max line length')
+parser.add_argument('files', type=str, nargs='+', help='list of file names')
+args = parser.parse_args()
+
+# force override line-length value
+lint_config = LintConfig()
+lint_config.get_rule_by_name_or_id('max-line-length').options['line-length'].value = args.max_line_length
+linter = lint.MarkdownLinter(lint_config)
+error_count = linter.lint_files(args.files)
+exit(error_count)

--- a/scripts/xmllint
+++ b/scripts/xmllint
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+
+import argparse
+import sys
+
+
+def raw_xml(filename):
+    xml_string = ''
+    with open(filename, 'r') as file:
+        for line in file:
+            xml_string += line
+    return(xml_string)
+
+# https://stackoverflow.com/questions/749796/pretty-printing-xml-in-python
+import lxml.etree as etree
+
+
+def pretty_xml(filename):
+    xml_string = ''
+    with open(filename, 'r') as file:
+        for line in file:
+            if line == "\n":  # preserve blank line
+                line = "<nr/>\n"
+            xml_string += line
+
+    try:
+        parser = etree.XMLParser(remove_blank_text=True, compact=False)
+        x = etree.XML(xml_string, parser)
+    except Exception as e:
+        print(e)
+        print("Failed to parse XML file {}".format(filename))
+        return None
+
+    # check white space within element and atributes
+    for element in x.iter():
+        if element.text:
+            element.text = element.text.strip()
+        for attr in element.keys():
+            element.attrib[attr] = element.attrib[attr].strip()
+
+    pretty_xml_as_string = etree.tostring(x, pretty_print=True, xml_declaration=True, with_tail=False)
+    pretty_xml_as_string = pretty_xml_as_string.replace('  <nr/>', '')
+    return(pretty_xml_as_string)
+
+# https://docs.python.org/2/library/difflib.html
+import difflib
+
+
+def diff(s1, s2):
+    s1 = s1.splitlines(1)[1:]
+    s2 = s2.splitlines(1)[1:]
+    diff = difflib.ndiff(s1, s2)
+    if list(s1) != list(s2):
+        return ''.join(diff)
+    else:
+        return None
+
+parser = argparse.ArgumentParser(description='markdownlint')
+parser.add_argument('--fix', action='store_true', help='fix input xml file')
+parser.add_argument('files', type=str, nargs='+', help='list of file names')
+args = parser.parse_args()
+
+error = False
+for filename in args.files:
+    xml_as_string = raw_xml(filename)
+    pretty_xml_as_string = pretty_xml(filename)
+    if pretty_xml_as_string is None:
+        error = True
+    else:
+        if args.fix:
+            with open(filename, 'w') as file:
+                file.write(pretty_xml_as_string)
+        else:
+            diff_string = diff(xml_as_string, pretty_xml_as_string)
+            if diff_string:  # diff
+                print("Lint error on {} file".format(filename))
+                print(diff_string)
+                error = True
+
+if error:
+    exit(-1)

--- a/src/roslint/README.md
+++ b/src/roslint/README.md
@@ -2,5 +2,10 @@ Acquiring these scripts:
 
     wget http://google-styleguide.googlecode.com/svn/trunk/cpplint/cpplint.py -O cpplint.py
     wget https://raw.github.com/jcrocholl/pep8/master/pep8.py -O pep8.py
+    wget https://github.com/jorisroovers/pymarkdownlint/raw/master/pymarkdownlint/lint.py -O pymarkdownlint_lint.py
+    wget https://github.com/jorisroovers/pymarkdownlint/raw/master/pymarkdownlint/rules.py -O pymarkdownlint_rules.py
+    wget https://github.com/jorisroovers/pymarkdownlint/raw/master/pymarkdownlint/options.py -O pymarkdownlint_options.py
+    sed -i 's/from pymarkdownlint import rules/import pymarkdownlint_rules as rules/' pymarkdownlint_lint.py
+    sed -i 's/from pymarkdownlint.options import IntOption/from pymarkdownlint_options import IntOption/' pymarkdownlint_rules.py
 
 TODO: Have CMake download them at package build time?

--- a/src/roslint/pymarkdownlint_lint.py
+++ b/src/roslint/pymarkdownlint_lint.py
@@ -1,0 +1,54 @@
+from __future__ import print_function
+import pymarkdownlint_rules as rules
+
+class MarkdownLinter(object):
+    def __init__(self, config):
+        self.config = config
+
+    @property
+    def line_rules(self):
+        return [rule for rule in self.config.rules if isinstance(rule, rules.LineRule)]
+
+    def _apply_line_rules(self, markdown_string):
+        """ Iterates over the lines in a given markdown string and applies all the enabled line rules to each line """
+        all_violations = []
+        lines = markdown_string.split("\n")
+        line_rules = self.line_rules
+        line_nr = 1
+        ignoring = False
+        for line in lines:
+            if ignoring:
+                if line.strip() == '<!-- markdownlint:enable -->':
+                    ignoring = False
+            else:
+                if line.strip() == '<!-- markdownlint:disable -->':
+                    ignoring = True
+                    continue
+
+                for rule in line_rules:
+                    violation = rule.validate(line)
+                    if violation:
+                        violation.line_nr = line_nr
+                        all_violations.append(violation)
+            line_nr += 1
+        return all_violations
+
+    def lint(self, markdown_string):
+        all_violations = []
+        all_violations.extend(self._apply_line_rules(markdown_string))
+        return all_violations
+
+    def lint_files(self, files):
+        """ Lints a list of files.
+        :param files: list of files to lint
+        :return: a list of violations found in the files
+        """
+        all_violations = []
+        for filename in files:
+            with open(filename, 'r') as f:
+                content = f.read()
+                violations = self.lint(content)
+                all_violations.extend(violations)
+                for e in violations:
+                    print("{0}:{1}: {2} {3}".format(filename, e.line_nr, e.rule_id, e.message))
+        return len(all_violations)

--- a/src/roslint/pymarkdownlint_options.py
+++ b/src/roslint/pymarkdownlint_options.py
@@ -1,0 +1,39 @@
+from abc import abstractmethod
+
+
+class RuleOptionError(Exception):
+    pass
+
+
+class RuleOption(object):
+    def __init__(self, name, value, description):
+        self.name = name
+        self.value = value
+        self.description = description
+
+    @abstractmethod
+    def set(self, value):
+        """ Validates and sets the option's value """
+        pass
+
+
+class IntOption(RuleOption):
+    def __init__(self, name, value, description, allow_negative=False):
+        super(IntOption, self).__init__(name, value, description)
+        self.allow_negative = allow_negative
+
+    def raise_exception(self, value):
+        if self.allow_negative:
+            error_msg = "Option '{0}' must be an integer (current value: {1})".format(self.name, value)
+        else:
+            error_msg = "Option '{0}' must be a positive integer (current value: {1})".format(self.name, value)
+        raise RuleOptionError(error_msg)
+
+    def set(self, value):
+        try:
+            self.value = int(value)
+        except ValueError:
+            self.raise_exception(value)
+
+        if not self.allow_negative and self.value < 0:
+            self.raise_exception(value)

--- a/src/roslint/pymarkdownlint_rules.py
+++ b/src/roslint/pymarkdownlint_rules.py
@@ -1,0 +1,83 @@
+from abc import abstractmethod, ABCMeta
+from pymarkdownlint_options import IntOption
+
+import re
+
+
+class Rule(object):
+    """ Class representing markdown rules. """
+    options_spec = []
+    id = []
+    name = ""
+    __metaclass__ = ABCMeta
+
+    def __init__(self, opts={}):
+        self.options = {}
+        for op_spec in self.options_spec:
+            self.options[op_spec.name] = op_spec
+            actual_option = opts.get(op_spec.name)
+            if actual_option:
+                self.options[op_spec.name].set(actual_option)
+
+    def __eq__(self, other):
+        return self.id == other.id and self.name == other.name
+
+    @abstractmethod
+    def validate(self):
+        pass
+
+
+class FileRule(Rule):
+    """ Class representing rules that act on an entire file """
+    pass
+
+
+class LineRule(Rule):
+    """ Class representing rules that act on a line by line basis """
+    pass
+
+
+class RuleViolation(object):
+    def __init__(self, rule_id, message, line_nr=None):
+        self.rule_id = rule_id
+        self.line_nr = line_nr
+        self.message = message
+
+    def __eq__(self, other):
+        return self.rule_id == other.rule_id and self.message == other.message and self.line_nr == other.line_nr
+
+    def __str__(self):
+        return "{0}: {1} {2}".format(self.line_nr, self.rule_id, self.message)
+
+    def __repr__(self):
+        return self.__str__()
+
+
+class MaxLineLengthRule(LineRule):
+    name = "max-line-length"
+    id = "R1"
+    options_spec = [IntOption('line-length', 80, "Max line length")]
+
+    def validate(self, line):
+        max_length = self.options['line-length'].value
+        if len(line) > max_length:
+            return RuleViolation(self.id, "Line exceeds max length ({0}>{1})".format(len(line), max_length))
+
+
+class TrailingWhiteSpace(LineRule):
+    name = "trailing-whitespace"
+    id = "R2"
+
+    def validate(self, line):
+        pattern = re.compile(r"\s$")
+        if pattern.search(line):
+            return RuleViolation(self.id, "Line has trailing whitespace")
+
+
+class HardTab(LineRule):
+    name = "hard-tab"
+    id = "R3"
+
+    def validate(self, line):
+        if "\t" in line:
+            return RuleViolation(self.id, "Line contains hard tab characters (\\t)")


### PR DESCRIPTION
- add roslint_xml

    Using lxml.tostring(pretty_print) to find dirty xml files

    For similar fixes in xml, try find . -iname *.xml -exec rosrun roslint
    xmllint --fix {} \;
-  add roslint_markdown

    Using pymarkdownlint to find dirty markdown files, specially tailing end, wrong indent

    using https://github.com/jorisroovers/pymarkdownlint
-  add roslint_catkin, which runs catkin_lint

    Runs catkin_lint within catkin run_tests   
    see https://github.com/fkie/catkin_lint for more info
-   add roslint_yaml function

   Runs yamllint to find dirty yaml files

   For similar fixes in YAML, try pretty-yaml
   (https://github.com/mk-fg/pretty-yaml) pip install --user pyaml
    find . -iname "*.yaml" -exec python -m pyaml -r {} \;