### PR TITLE
[Noetic] Use catkin_install_python() to fix shebangs for python 3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,11 @@ find_package(catkin REQUIRED)
 catkin_package(CFG_EXTRAS roslint-extras.cmake)
 catkin_python_setup()
 
-install(PROGRAMS scripts/cpplint scripts/pep8 scripts/test_wrapper
+install(PROGRAMS scripts/test_wrapper
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+catkin_install_python(PROGRAMS scripts/cpplint scripts/pep8
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 


### PR DESCRIPTION
This uses [`catkin_install_python()`](https://github.com/ros/catkin/blob/0baff3a78c3ca1fcbf65493a8d656054a61a6c12/cmake/catkin_install_python.cmake#L1-L13) to make sure the shebangs of the python scripts `cpplint` and `pep8` get rewritten to use the correct version of python. This fixes a bug where these scripts are being run using python 2 in Noetic.

More info here: http://wiki.ros.org/UsingPython3/SourceCodeChanges#Changing_shebangs