### PR TITLE
Python3 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ install(PROGRAMS scripts/test_wrapper
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
-catkin_install_python(PROGRAMS scripts/cpplint scripts/pep8
+catkin_install_python(PROGRAMS scripts/cpplint scripts/pycodestyle
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,11 @@ find_package(catkin REQUIRED)
 catkin_package(CFG_EXTRAS roslint-extras.cmake)
 catkin_python_setup()
 
-install(PROGRAMS scripts/cpplint scripts/pep8 scripts/test_wrapper
+install(PROGRAMS scripts/test_wrapper
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+catkin_install_python(PROGRAMS scripts/cpplint scripts/pep8
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 

--- a/cmake/roslint-extras.cmake.em
+++ b/cmake/roslint-extras.cmake.em
@@ -39,7 +39,7 @@ function(roslint_custom linter lintopts)
     _roslint_create_targets()
     add_custom_command(TARGET roslint_${PROJECT_NAME} POST_BUILD
                        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-                       COMMAND ${linter} ${lintopts} ${ARGN} VERBATIM)
+                       COMMAND ${CATKIN_ENV} ${linter} ${lintopts} ${ARGN} VERBATIM)
   endif()
 endfunction()
 
@@ -62,7 +62,7 @@ function(roslint_python)
     file(GLOB_RECURSE ARGN *.py)
   endif()
   if (NOT DEFINED ROSLINT_PYTHON_CMD)
-    set(ROSLINT_PYTHON_CMD ${ROSLINT_SCRIPTS_DIR}/pep8)
+    set(ROSLINT_PYTHON_CMD ${ROSLINT_SCRIPTS_DIR}/pycodestyle)
   endif()
   roslint_custom("${ROSLINT_PYTHON_CMD}" "${ROSLINT_PYTHON_OPTS}" ${ARGN})
 endfunction()
@@ -70,6 +70,6 @@ endfunction()
 # Run roslint for this package as a test.
 function(roslint_add_test)
   catkin_run_tests_target("roslint" "package" "roslint-${PROJECT_NAME}.xml"
-    COMMAND "${ROSLINT_SCRIPTS_DIR}/test_wrapper ${CATKIN_TEST_RESULTS_DIR}/${PROJECT_NAME}/roslint-${PROJECT_NAME}.xml make roslint_${PROJECT_NAME}"
+    COMMAND ${ROSLINT_SCRIPTS_DIR}/test_wrapper ${CATKIN_TEST_RESULTS_DIR}/${PROJECT_NAME}/roslint-${PROJECT_NAME}.xml make roslint_${PROJECT_NAME}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 endfunction()

--- a/scripts/pycodestyle
+++ b/scripts/pycodestyle
@@ -2,14 +2,13 @@
 
 import sys
 try:
-    from roslint import pep8
+    from roslint import pycodestyle
 except ImportError:
     # Allows the target to work with an un-sourced workspace.
     import os.path
     sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "src"))
-    from roslint import pep8
+    from roslint import pycodestyle
 
-# Prepend max line-length so that user can overide it. The number is 1
-# since 0 is the name of the program.
-sys.argv.insert(1, "--max-line-length=120")
-pep8._main()
+pycodestyle.MAX_LINE_LENGTH = 120
+
+pycodestyle._main()

--- a/src/roslint/README.md
+++ b/src/roslint/README.md
@@ -1,6 +1,21 @@
-Acquiring these scripts:
+For overall stability and to avoid a packaging headache, the linters in use are
+vendored into this packages.
+
+python
+======
+
+The python linter is `pycodestyle` (nee `pep8`), and can be downloaded from here:
+
+    wget https://raw.githubusercontent.com/PyCQA/pycodestyle/master/pycodestyle.py -O pycodestyle.py
+
+C++
+===
+
+The C++ linter is `cpplint.py` which is downloaded from here:
 
     wget https://raw.githubusercontent.com/google/styleguide/gh-pages/cpplint/cpplint.py -O cpplint.py
-    wget https://raw.github.com/jcrocholl/pep8/master/pep8.py -O pep8.py
 
-TODO: Have CMake download them at package build time?
+However, the current master branch version of cpplint does not run cleanly under Python 3, so
+a small patch has been applied to resolve this based on this pull request:
+
+https://github.com/google/styleguide/pull/349

--- a/src/roslint/cpplint.py
+++ b/src/roslint/cpplint.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (c) 2009 Google Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -57,7 +55,12 @@ try:
   xrange          # Python 2
 except NameError:
   xrange = range  # Python 3
-
+  unicode = str
+else:
+  sys.stderr = codecs.StreamReaderWriter(sys.stderr,
+                                         codecs.getreader('utf8'),
+                                         codecs.getwriter('utf8'),
+                                         'replace')
 
 _USAGE = """
 Syntax: cpplint.py [--verbose=#] [--output=vs7] [--filter=-x,+y,...]
@@ -952,7 +955,7 @@ class _CppLintState(object):
 
   def PrintErrorCounts(self):
     """Print a summary of errors by category, and the total."""
-    for category, count in self.errors_by_category.iteritems():
+    for category, count in self.errors_by_category.items():
       sys.stderr.write('Category \'%s\' errors found: %d\n' %
                        (category, count))
     sys.stdout.write('Total errors found: %d\n' % self.error_count)
@@ -4622,7 +4625,7 @@ def _GetTextInside(text, start_pattern):
 
   # Give opening punctuations to get the matching close-punctuations.
   matching_punctuation = {'(': ')', '{': '}', '[': ']'}
-  closing_punctuation = set(matching_punctuation.itervalues())
+  closing_punctuation = set(matching_punctuation.values())
 
   # Find the position to start extracting text.
   match = re.search(start_pattern, text, re.M)
@@ -6222,13 +6225,6 @@ def ParseArguments(args):
 
 def main():
   filenames = ParseArguments(sys.argv[1:])
-
-  # Change stderr to write with replacement characters so we don't die
-  # if we try to print something containing non-ASCII characters.
-  sys.stderr = codecs.StreamReaderWriter(sys.stderr,
-                                         codecs.getreader('utf8'),
-                                         codecs.getwriter('utf8'),
-                                         'replace')
 
   _cpplint_state.ResetErrorCounts()
   for filename in filenames:

--- a/src/roslint/cpplint_wrapper.py
+++ b/src/roslint/cpplint_wrapper.py
@@ -141,7 +141,7 @@ def ProcessLine(fn, filename, file_extension, clean_lines, line,
 def CheckEmptyBlockBody(fn, filename, clean_lines, linenum, error):
     """ Look for empty loop/conditional body with only a single semicolon,
         but allow ros-style do while loops. """
-    from cpplint import CloseExpression
+    from roslint.cpplint import CloseExpression
 
     # Search for loop keywords at the beginning of the line.  Because only
     # whitespaces are allowed before the keywords, this will also ignore most


### PR DESCRIPTION
This change incorporates #72 and #73, and includes an additional change in 65bfeadece81084442e2ed4b48b8652de39aebd9, which is based on https://github.com/google/styleguide/pull/349, to make it work under Python 3.

It's pretty hacky (`unicode = str`, etc), but I think this is probably the least-effort path to get this going that doesn't involve taking on cpplint ourselves.

Ping @sloretz.