### PR TITLE
Fix distutils.core -> setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 setup(**generate_distutils_setup(


### PR DESCRIPTION
Setuptools v60+ now throw errors about this. Other core packages were changed 2+ years ago, eg https://github.com/ros/ros_comm/pull/1870