### PR TITLE
Call _roslint_create_targets() in roslint_add_test

### DIFF
--- a/cmake/roslint-extras.cmake.em
+++ b/cmake/roslint-extras.cmake.em
@@ -69,6 +69,7 @@ endfunction()
 
 # Run roslint for this package as a test.
 function(roslint_add_test)
+  _roslint_create_targets()
   catkin_run_tests_target("roslint" "package" "roslint-${PROJECT_NAME}.xml"
     COMMAND "${ROSLINT_SCRIPTS_DIR}/test_wrapper ${CATKIN_TEST_RESULTS_DIR}/${PROJECT_NAME}/roslint-${PROJECT_NAME}.xml make roslint_${PROJECT_NAME}"
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION
I have a CMakeLists.txt with some conditions determining when to run various roslint tests. Now it happened to me that all tests got disabled, but the call to `roslint_add_test()` was still there. In such case, running tests fails with:

```
Scanning dependencies of target _run_tests_cras_docs_common_roslint_package
-- run_tests.py: execute commands with working directory "/tmp/ws/build_isolated/cras_docs_common"
  /opt/ros/noetic/share/roslint/cmake/../../../lib/roslint/test_wrapper /tmp/ws/test_results/cras_docs_common/roslint-cras_docs_common.xml make roslint_cras_docs_common
make[4]: *** No rule to make target 'roslint_cras_docs_common'.  Stop.
```

I.e. the `roslint_<PACKAGE>` target does not exist, but is registered to be run. Calling `_roslint_create_targets()` in `roslint_add_test()` should not harm anything and fixes this case.