### PR TITLE
avoid printing on stderr if linter successful

### DIFF
--- a/scripts/test_wrapper
+++ b/scripts/test_wrapper
@@ -1,12 +1,11 @@
 #!/bin/bash
 
-set -o pipefail
-
 RESULTS_FILE=$1
 TARGET_NAME=${@: -1}
 shift
 
 # Run remain args as test command, capturing the output.
+LINTER_OUTPUT=$( $@ 2>&1 )
 LINTER_RESULT=$?
 
 mkdir -p `dirname $RESULTS_FILE`
@@ -21,7 +20,7 @@ ENDXML
   exit 0
 else
   # Lint failed
-LINTER_OUTPUT=$( $@ 2>&1 | tee /dev/stderr )
+  >&2 echo $LINTER_OUTPUT
   # TODO: This output could be more helpful; really just a first cut.
  cat <<ENDXML > $RESULTS_FILE
 <?xml version="1.0" encoding="UTF-8"?>

--- a/scripts/test_wrapper
+++ b/scripts/test_wrapper
@@ -5,12 +5,13 @@ TARGET_NAME=${@: -1}
 shift
 
 # Run remain args as test command, capturing the output.
-LINTER_OUTPUT=$( $@ 2>&1 )
+LINTER_OUTPUT="$( $@ 2>&1 )"
 LINTER_RESULT=$?
 
 mkdir -p `dirname $RESULTS_FILE`
 if [[ "$LINTER_RESULT" == "0" ]]; then
   # Lint pass
+echo "$LINTER_OUTPUT"
 cat <<ENDXML > $RESULTS_FILE
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuite name="roslint" tests="1" failures="0" errors="0">
@@ -20,9 +21,9 @@ ENDXML
   exit 0
 else
   # Lint failed
-  >&2 echo $LINTER_OUTPUT
-  # TODO: This output could be more helpful; really just a first cut.
- cat <<ENDXML > $RESULTS_FILE
+echo "$LINTER_OUTPUT" >&2
+# TODO: This output could be more helpful; really just a first cut.
+cat <<ENDXML > $RESULTS_FILE
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuite name="roslint" tests="1" failures="1" errors="0">
   <testcase name="$TARGET_NAME" classname="roslint.LintCheck">

--- a/scripts/test_wrapper
+++ b/scripts/test_wrapper
@@ -7,7 +7,6 @@ TARGET_NAME=${@: -1}
 shift
 
 # Run remain args as test command, capturing the output.
-LINTER_OUTPUT=$( $@ 2>&1 | tee /dev/stderr )
 LINTER_RESULT=$?
 
 mkdir -p `dirname $RESULTS_FILE`
@@ -22,6 +21,7 @@ ENDXML
   exit 0
 else
   # Lint failed
+LINTER_OUTPUT=$( $@ 2>&1 | tee /dev/stderr )
   # TODO: This output could be more helpful; really just a first cut.
  cat <<ENDXML > $RESULTS_FILE
 <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
Hey there :wave:

Thanks for this utility!
I'm experimenting it to invoke `catkin_lint` as described in https://discourse.ros.org/t/ros1-now-is-a-great-time-to-add-catkin-lint-to-your-packages/36521
To be precise I'm invoking it like this `roslint_custom(catkin_lint -W2 --strict -q .)`)
An issue I face is that it is generating a catkin_tools warning on each package it is used even if the linter passes.

This PR is a workaround for this issue. I guess it doesnt have a strong impact as this pipe was not present in earlier version of ROS 1 (https://github.com/ros/roslint/pull/79/files#diff-75b2bc3dc9e3948395dbe27abe404923f62e0fbf445bdada52b0ce5264b4b186) but I actually have no idea of the potential impact.

<details><summary>Catkin build logs without and with this change</summary>

Without this change:
```
==> Expanding alias 'run_tests' from 'catkin run_tests test_pkg' to 'catkin test test_pkg'
Starting  >>> test_pkg                                                                                                                                                                              
__________________________________________________________________________________________________________________________________________________________________________________________________________
Warnings   << test_pkg:make /home/mikael/dev/catkin_ws/logs/test_pkg/test.make.014.log                                                                                                        
-- run_tests.py: execute commands with working directory "/home/mikael/dev/catkin_ws/build/test_pkg"
  /opt/ros/noetic/share/roslint/cmake/../../../lib/roslint/test_wrapper /home/mikael/dev/catkin_ws/build/test_pkg/test_results/test_pkg/roslint-test_pkg.xml make roslint_test_pkg
Built target roslint_test_pkg
cd /home/mikael/dev/catkin_ws/build/test_pkg; catkin test --get-env test_pkg | catkin env -si  /usr/bin/make run_tests; cd -

..........................................................................................................................................................................................................
Output     << test_pkg:results /home/mikael/dev/catkin_ws/logs/test_pkg/test.results.014.log                                                                                                  
Summary: 1 tests, 0 errors, 0 failures, 0 skipped
cd /home/mikael/dev/catkin_ws/build/test_pkg; catkin test --get-env test_pkg | catkin env -si  catkin_test_results; cd -
                   
Finished  <<< test_pkg          [ 0.7 seconds ]                                                                                                                                                     
[test] Summary: All 1 packages succeeded!                                                                                                                                                                 
[test]   Ignored:   None.                                                                                                                                                                                 
[test]   Warnings:  1 packages succeeded with warnings.                                                                                                                                                   
[test]   Abandoned: None.                                                                                                                                                                                 
[test]   Failed:    None.                                                                                                                                                                                 
[test] Runtime: 0.7 seconds total.                        
```

With this change
```
==> Expanding alias 'run_tests' from 'catkin run_tests test_pkg' to 'catkin test test_pkg'
Starting  >>> test_pkg                                                                       
Output     << test_pkg:make /home/mikael/dev/catkin_ws/logs/test_pkg/test.make.013.log 
-- run_tests.py: execute commands with working directory "/home/mikael/dev/catkin_ws/build/test_pkg"
  /opt/ros/noetic/share/roslint/cmake/../../../lib/roslint/test_wrapper /home/mikael/dev/catkin_ws/build/test_pkg/test_results/test_pkg/roslint-test_pkg.xml make roslint_test_pkg
cd /home/mikael/dev/catkin_ws/build/test_pkg; catkin test --get-env test_pkg | catkin env -si  /usr/bin/make run_tests; cd -

Output     << test_pkg:results /home/mikael/dev/catkin_ws/logs/test_pkg/test.results.013.log
Summary: 1 tests, 0 errors, 0 failures, 0 skipped
cd /home/mikael/dev/catkin_ws/build/test_pkg; catkin test --get-env test_pkg | catkin env -si  catkin_test_results; cd -

Finished  <<< test_pkg          [ 0.3 seconds ]                                              
[test] Summary: All 1 packages succeeded!                                                          
[test]   Ignored:   None.                                                                          
[test]   Warnings:  None.                                                                          
[test]   Abandoned: None.                                                                          
[test]   Failed:    None.                                                                          
[test] Runtime: 0.3 seconds total.   
```
</details>

@peci1 FYI as I may be using this wrong and maybe there is a better way around it ?