### PR TITLE
Fix dict change during iteration

### DIFF
--- a/src/roslint/cpplint.py
+++ b/src/roslint/cpplint.py
@@ -5573,7 +5573,7 @@ def CheckForIncludeWhatYouUse(filename, clean_lines, include_state, error,
 
   # include_dict is modified during iteration, so we iterate over a copy of
   # the keys.
-  header_keys = include_dict.keys()
+  header_keys = list(include_dict.keys())
   for header in header_keys:
     (same_module, common_path) = FilesBelongToSameModule(abs_filename, header)
     fullpath = common_path + header


### PR DESCRIPTION
Without this PR, I got an exception from cpplint saying that the dict iterated over has been changed during iteration.

The comment above my change says we operate on a copy, but it's not actually creating a copy (I think it gets a generator). So I instead forced the copy.